### PR TITLE
Minor typo fix

### DIFF
--- a/scripts/krakenhll-extract-reads
+++ b/scripts/krakenhll-extract-reads
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 # (c) 2015-2017 Steven Salzberg and Florian Breitwieser
 # part of KrakenHLL
 # licensed under GPL-3


### PR DESCRIPTION
The `krakenhll-extract-reads` script is not working due to a typo in the shebang. 