### PR TITLE
Fix jellyfish detection

### DIFF
--- a/scripts/krakenhll-check_for_jellyfish.sh
+++ b/scripts/krakenhll-check_for_jellyfish.sh
@@ -27,7 +27,7 @@ set -o pipefail  # Stop on failures in non-final pipeline commands
 
 JELLYFISH1_BIN=""
 for JF in $JELLYFISH_BIN $(dirname $0)/jellyfish/bin/jellyfish  /usr/local/opt/jellyfish-1.1/bin/jellyfish jellyfish1 jellyfish; do
-  if test -f $JF || command -v $JF 2>/dev/null; then
+  if test -f $JF || command -v $JF >/dev/null 2>&1; then
     JELLYFISH1_BIN=$JF;
     break
   fi


### PR DESCRIPTION
On some versions of bash, `command -v jellyfish` outputs the path to jellyfish to stdout and results in $JELLYFISH_BIN having two paths to `jellyfish` separated by a newline (which obviously breaks the `build_db` script). I've modified it here to redirect the stdout along with the stderr to /dev/null which should fix this edge case.